### PR TITLE
Change `QhBuilder` methods for #12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -235,6 +235,7 @@ dependencies = [
  "qhull-sys",
  "rand",
  "svg",
+ "thiserror",
 ]
 
 [[package]]
@@ -346,13 +347,33 @@ checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ include = [
 
 [dependencies]
 qhull-sys = { version = "0.3", path = "qhull-sys", features = [ "include-programs" ]}
+thiserror = "2.0.11"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/qhull-sys/src/lib.rs
+++ b/qhull-sys/src/lib.rs
@@ -15,7 +15,7 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 pub const QHULL_LICENSE_TEXT: &str = include_str!("../qhull/COPYING.txt");
 
-fn str_from_i32_array<'a>(data: &'a [i8]) -> Result<&'a CStr, FromBytesUntilNulError> {
+fn str_from_c_char_array<'a>(data: &'a [core::ffi::c_char]) -> Result<&'a CStr, FromBytesUntilNulError> {
     unsafe {
         CStr::from_bytes_until_nul(core::slice::from_raw_parts(
             data.as_ptr() as *const u8,
@@ -144,10 +144,10 @@ impl Debug for qhT {
             .field("POINTSmalloc", &self.POINTSmalloc)
             .field("input_points", &self.input_points)
             .field("input_malloc", &self.input_malloc)
-            .field("qhull_command", &str_from_i32_array(&self.qhull_command))
+            .field("qhull_command", &str_from_c_char_array(&self.qhull_command))
             .field("qhull_commandsiz2", &self.qhull_commandsiz2)
-            .field("rbox_command", &str_from_i32_array(&self.rbox_command))
-            .field("qhull_options", &str_from_i32_array(&self.qhull_options))
+            .field("rbox_command", &str_from_c_char_array(&self.rbox_command))
+            .field("qhull_options", &str_from_c_char_array(&self.qhull_options))
             .field("qhull_optionlen", &self.qhull_optionlen)
             .field("qhull_optionsiz", &self.qhull_optionsiz)
             .field("qhull_optionsiz2", &self.qhull_optionsiz2)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -609,6 +609,6 @@ mod type_mapping {
     pub type int = i32;
     pub type pointT = f64;
     pub type coordT = f64;
-    pub type char = i8;
+    pub type char = core::ffi::c_char;
     pub type qh_PRINT = sys::qh_PRINT;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,6 @@ struct OwnedValues {
     upper_bound: Option<Rc<Vec<f64>>>,
     lower_bound: Option<Rc<Vec<f64>>>,
     feasible_point: Option<Rc<Vec<f64>>>,
-    feasible_string: Option<Rc<Vec<i8>>>,
+    feasible_string: Option<Rc<Vec<core::ffi::c_char>>>,
     near_zero: Option<Rc<Vec<f64>>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::{cell::{RefCell, UnsafeCell}, marker::PhantomData, rc::Rc};
+use std::{cell::{RefCell, UnsafeCell}, ffi::CString, marker::PhantomData};
 
 use helpers::{prepare_delaunay_points, CollectedCoords, QhTypeRef};
 use io_buffers::IOBuffers;
@@ -278,14 +278,14 @@ impl<'a> Drop for Qh<'a> {
 #[derive(Default)]
 #[allow(unused)]
 struct OwnedValues {
-    good_point_coords: Option<Rc<Vec<f64>>>,
-    good_vertex_coords: Option<Rc<Vec<f64>>>,
-    first_point: Option<Rc<Vec<f64>>>,
-    upper_threshold: Option<Rc<Vec<f64>>>,
-    lower_threshold: Option<Rc<Vec<f64>>>,
-    upper_bound: Option<Rc<Vec<f64>>>,
-    lower_bound: Option<Rc<Vec<f64>>>,
-    feasible_point: Option<Rc<Vec<f64>>>,
-    feasible_string: Option<Rc<Vec<core::ffi::c_char>>>,
-    near_zero: Option<Rc<Vec<f64>>>,
+    good_point_coords: Option<Vec<f64>>,
+    good_vertex_coords: Option<Vec<f64>>,
+    first_point: Option<Vec<f64>>,
+    upper_threshold: Option<Vec<f64>>,
+    lower_threshold: Option<Vec<f64>>,
+    upper_bound: Option<Vec<f64>>,
+    lower_bound: Option<Vec<f64>>,
+    feasible_point: Option<Vec<f64>>,
+    feasible_string: Option<CString>,
+    near_zero: Option<Vec<f64>>,
 }


### PR DESCRIPTION
Fixes #12.

Concerns about exposing `c_char` have been expressed in #10. This tries to replace `QhBuilder` methods with more "user-friendly" ones using `&str`. `InvalidStringError` is added.