### PR TITLE
Fix: output contains non-triangle faces even if triangulate is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -235,6 +235,7 @@ dependencies = [
  "qhull-sys",
  "rand",
  "svg",
+ "thiserror",
 ]
 
 [[package]]
@@ -346,13 +347,33 @@ checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ include = [
 
 [dependencies]
 qhull-sys = { version = "0.3", path = "qhull-sys", features = [ "include-programs" ]}
+thiserror = "2.0.11"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/qhull-sys/wrapper.h
+++ b/qhull-sys/wrapper.h
@@ -1,1 +1,2 @@
 #include <libqhull_r.h>
+#include <io_r.h>

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -229,6 +229,7 @@ impl QhBuilder {
                 if self.check_points {
                     qh.check_points().map_err(|e| e.into_static())?;
                 }
+                qh.prepare_output().map_err(|e| e.into_static())?;
             }
 
             Ok(qh)
@@ -418,7 +419,7 @@ macro_rules! add_setting {
         #[doc = add_setting!(basic documentation: $setter => $qhull_name: $($orig_doc)?)]
         $(#[$meta])*
         #[doc = add_setting!(safety documentation: unsafe)]
-        pub unsafe fn $setter(mut self, $setter: &str) -> Result<Self, InvalidStringError> { // or maybe QhError or something else?
+        pub fn $setter(mut self, $setter: &str) -> Result<Self, InvalidStringError> { // or maybe QhError or something else?
             let bytes = std::ffi::CString::new($setter)?
                 .as_bytes_with_nul()
                 .iter()
@@ -449,7 +450,7 @@ macro_rules! add_setting {
         #[doc = add_setting!(basic documentation: $setter => $qhull_name: $($orig_doc)?)]
         $(#[$meta])*
         #[doc = add_setting!(safety documentation: unsafe)]
-        pub unsafe fn $setter(mut self, $setter: &str) -> Result<Self, InvalidStringError> { // or maybe QhError or something else?
+        pub fn $setter(mut self, $setter: &str) -> Result<Self, InvalidStringError> { // or maybe QhError or something else?
             let $setter = std::ffi::CString::new($setter)?;
             self = unsafe {
                 self.with_configure(move |qh| {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -100,7 +100,7 @@ impl QhBuilder {
 
     /// Set whether to compute the hull when building the Qhull instance
     ///
-    /// When enabled, [`Qh::compute`] will be called.
+    /// When enabled, [`Qh::compute`] and [`Qh::prepare_output`] will be called.
     /// When disabled, you will have to call this method manually.
     ///
     /// # Example
@@ -226,10 +226,10 @@ impl QhBuilder {
                 if self.check_output {
                     qh.check_output().map_err(|e| e.into_static())?;
                 }
+                qh.prepare_output().map_err(|e| e.into_static())?;
                 if self.check_points {
                     qh.check_points().map_err(|e| e.into_static())?;
                 }
-                qh.prepare_output().map_err(|e| e.into_static())?;
             }
 
             Ok(qh)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -656,3 +656,77 @@ mod type_mapping {
     pub type coordT = f64;
     pub type qh_PRINT = sys::qh_PRINT;
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Qh;
+
+    #[test]
+    fn triangulate() {
+        // from https://github.com/LucaCiucci/qhull-rs/issues/15
+        let points = [
+            [10.0, -1000.0, 0.0],
+            [-838.3645082073471, -1000.0, 0.0],
+            [0.0, -1000.0, 0.5],
+            [0.0, -1000.0, -1.0],
+            [0.0, 0.0, 0.0],
+        ];
+
+        let qh = Qh::builder()
+            .compute(true)
+            .triangulate(false)
+            .build_from_iter(points.into_iter())
+            .expect("Failed to compute convex hull");
+
+        let faces = qh
+            .facets()
+            .map(|face| face
+                .vertices()
+                .unwrap()
+                .iter()
+                .map(|v| v.point_id(&qh).unwrap())
+                .collect::<Vec<_>>()
+            )
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            faces,
+            vec![
+                vec![3, 4, 1],
+                vec![3, 4, 0],
+                vec![2, 4, 1],
+                vec![2, 4, 0],
+                vec![2, 3, 0, 1],
+            ]
+        );
+
+        let qh = Qh::builder()
+            .compute(true)
+            .triangulate(true)
+            .build_from_iter(points.into_iter())
+            .expect("Failed to compute convex hull");
+
+        let faces = qh
+            .facets()
+            .map(|face| face
+                .vertices()
+                .unwrap()
+                .iter()
+                .map(|v| v.point_id(&qh).unwrap())
+                .collect::<Vec<_>>()
+            )
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            faces,
+            vec![
+                vec![3, 4, 1],
+                vec![3, 4, 0],
+                vec![2, 4, 1],
+                vec![2, 4, 0],
+                vec![2, 3, 0],
+                vec![2, 3, 1],
+            ]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,15 +39,22 @@ impl<'a> Qh<'a> {
     }
 
     /// Compute the convex hull
+    ///
+    /// Wraps [`qhull_sys::qh_qhull`],
     pub fn compute(&mut self) -> Result<(), QhError> {
         unsafe { Qh::try_on_qh_mut(self, |qh| sys::qh_qhull(qh)) }
     }
 
+    /// Prepare the output of the qhull instance
+    ///
+    /// Wraps [`qhull_sys::qh_prepare_output`],
     pub fn prepare_output(&mut self) -> Result<(), QhError> {
         unsafe { Qh::try_on_qh_mut(self, |qh| sys::qh_prepare_output(qh)) }
     }
 
     /// Check the output of the qhull instance
+    ///
+    /// Wraps [`qhull_sys::qh_check_output`],
     pub fn check_output(&mut self) -> Result<(), QhError> {
         unsafe { Qh::try_on_qh_mut(self, |qh| sys::qh_check_output(qh)) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,10 @@ impl<'a> Qh<'a> {
         unsafe { Qh::try_on_qh_mut(self, |qh| sys::qh_qhull(qh)) }
     }
 
+    pub fn prepare_output(&mut self) -> Result<(), QhError> {
+        unsafe { Qh::try_on_qh_mut(self, |qh| sys::qh_prepare_output(qh)) }
+    }
+
     /// Check the output of the qhull instance
     pub fn check_output(&mut self) -> Result<(), QhError> {
         unsafe { Qh::try_on_qh_mut(self, |qh| sys::qh_check_output(qh)) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::{cell::{RefCell, UnsafeCell}, marker::PhantomData, rc::Rc};
+use std::{cell::{RefCell, UnsafeCell}, ffi::CString, marker::PhantomData};
 
 use helpers::{prepare_delaunay_points, CollectedCoords, QhTypeRef};
 use io_buffers::IOBuffers;
@@ -278,14 +278,14 @@ impl<'a> Drop for Qh<'a> {
 #[derive(Default)]
 #[allow(unused)]
 struct OwnedValues {
-    good_point_coords: Option<Rc<Vec<f64>>>,
-    good_vertex_coords: Option<Rc<Vec<f64>>>,
-    first_point: Option<Rc<Vec<f64>>>,
-    upper_threshold: Option<Rc<Vec<f64>>>,
-    lower_threshold: Option<Rc<Vec<f64>>>,
-    upper_bound: Option<Rc<Vec<f64>>>,
-    lower_bound: Option<Rc<Vec<f64>>>,
-    feasible_point: Option<Rc<Vec<f64>>>,
-    feasible_string: Option<Rc<Vec<core::ffi::c_char>>>,
-    near_zero: Option<Rc<Vec<f64>>>,
+    good_point_coords: Option<Vec<f64>>,
+    good_vertex_coords: Option<Vec<f64>>,
+    first_point: Option<Vec<f64>>,
+    upper_threshold: Option<Vec<f64>>,
+    lower_threshold: Option<Vec<f64>>,
+    upper_bound: Option<Vec<f64>>,
+    lower_bound: Option<Vec<f64>>,
+    feasible_point: Option<Vec<f64>>,
+    feasible_string: Option<CString>,
+    near_zero: Option<Vec<f64>>,
 }


### PR DESCRIPTION
Fixes #15

The reference usage (`qconvex_r.c`) calls `qh_produce_output` to generate the triangulation:
https://github.com/qhull/qhull/blob/89341b937a90ae8dc19e13a2bd4225d3c9abe4c2/src/qconvex/qconvex_r.c#L329

This pull request is currently marked as a draft due to the following considerations:
- the call to `prepare_output` might need to be optional
- `qh_prepare_output` comes from `io_r.h` which we might not want to expose, we might prefer using the referenced methods directly (`qh_clearcenters`, `qh_triangulate`, etc.)