### PR TITLE
Fix error handling with MSVC

### DIFF
--- a/qhull-sys/src/error_handling.c
+++ b/qhull-sys/src/error_handling.c
@@ -3,13 +3,14 @@
 
 int qhull_sys__try_on_qh(
     qhT* qh,
-    void (*fn)(qhT* qh, void* data),
+    void (*fn)(void* data),
     void* data
 ) {
     // See definition of QH_TRY_NO_THROW_ for reference
 
     if (!qh || !fn) {
         printf("qh or fn is NULL\n");
+        fflush(stdout);
         return QH_TRY_ERROR;
     }
 
@@ -22,13 +23,14 @@ int qhull_sys__try_on_qh(
     } else {
         // try_on_qh was nested
         printf("try_on_qh was nested\n");
+        fflush(stdout);
         try_status = QH_TRY_ERROR;
     }
 
     // do not execute the function if an error occurred and we
     // jumped back to the setjmp point
     if (try_status == 0) {
-        fn(qh, data);
+        fn(data);
     }
 
     qh->NOerrexit = True;

--- a/qhull-sys/src/error_handling.h
+++ b/qhull-sys/src/error_handling.h
@@ -7,7 +7,7 @@
 
 int qhull_sys__try_on_qh(
     qhT* qh,
-    void (*fn)(qhT* qh, void* data),
+    void (*fn)(void* data),
     void* data
 );
 

--- a/src/types/vertex.rs
+++ b/src/types/vertex.rs
@@ -89,9 +89,13 @@ impl<'a> Vertex<'a> {
     pub fn point_id<'b>(&self, qh: &'b Qh) -> Result<i32, QhError<'b>> {
         unsafe {
             let ptr = self.raw_ref().point;
-            Qh::try_on_qh(&qh, |qh| {
-                qhull_sys::qh_pointid(qh as *mut _, ptr as *mut _)
-            })
+            let qh_ptr = Qh::raw_ptr(qh);
+            QhError::try_2(
+                qh_ptr,
+                &mut qh.buffers().borrow_mut().err_file,
+                qhull_sys::qh_pointid,
+                (qh.qh.get(), ptr as *mut _),
+            )
         }
     }
 


### PR DESCRIPTION
Fixes #11.
Currently, `setjmp` and `longjmp` don't play whell with Rust as mentioned by several sources. The specific problem here was that the lambdas that we used to wrap fallible qhull functions were probably interacting with the exception handling on MSVC (I did not investigate further).  
This fix avoids using lambdas at the cost of having separate functions for "trying" qhull functions depending on the number of arguments.  

I did not investigate further what exactly happens when qhull calls `longjmp` and the usage of `setjmp` is technically still invalid but seems to fix the issue for now.