### PR TITLE
Fix memory leak by properly freeing Qhull short memory in Drop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,9 @@ impl<'a> Drop for Qh<'a> {
     fn drop(&mut self) {
         unsafe {
             sys::qh_freeqhull(self.qh.get_mut(), !sys::qh_ALL);
+            let mut curlong: i32 = 0;
+            let mut totlong: i32 = 0;
+            sys::qh_memfreeshort(self.qh.get_mut(), &mut curlong, &mut totlong);
         }
     }
 }


### PR DESCRIPTION
Hi! 👋

I think I found a memory leak. I hope this change will solve the problem.

## Problem

The current `Drop` implementation for `Qh` was not properly freeing all memory allocated by Qhull. When calling `qh_freeqhull` with `!qh_ALL` (false), only long-term memory structures (facets, vertices, ridges) are freed, but short-term memory allocated by Qhull remains unfreed, causing memory leaks.

I noticed that when running my application for extended periods, the memory usage kept growing. After investigating with memory profiling tools, I discovered that each `Qh` instance was leaking memory on drop.

## Solution

Added a call to `qh_memfreeshort` after `qh_freeqhull` to properly free the short-term memory and memory allocator. This follows the correct cleanup sequence as documented in Qhull's API.  
https://github.com/qhull/qhull/blob/d7e4615571df53cf8eedd657052cfe49bd78e244/src/libqhull/global.c#L455-L474

## Changes

- Added `qh_memfreeshort` call in `Drop` implementation for `Qh`

## How to check

I created a simple script in the example directory and used `leaks` command on macOS to check for memory leaks.

```rust
use qhull::Qh;

fn main() {
    println!("Starting memory leak test...");

    for i in 0..100 {
        let qh = Qh::builder()
            .compute(true)
            .build_from_iter([
                [0.0, 0.0],
                [1.0, 0.0],
                [0.0, 1.0],
                [0.25, 0.25],
                [0.5, 0.5],
                [0.75, 0.1],
            ])
            .unwrap();

        let _num_vertices = qh.num_vertices();
        for simplex in qh.simplices().take(1) {
            let _vertices: Vec<_> = simplex
                .vertices()
                .unwrap()
                .iter()
                .map(|v| v.index(&qh).unwrap())
                .collect();
        }

        if i % 10 == 0 {
            println!("Iteration {} completed", i);
        }
    }

    println!("Test completed. Check for memory leaks.");
}
```

```shell
cargo build --example leak_test
leaks --atExit -- ./target/debug/examples/leak_test
```

### Before

```txt
Process:         leak_test [55533]
Path:            /Users/USER/*/leak_test
Load Address:    0x104f1c000
Identifier:      leak_test
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [55532]
Target Type:     live task

Date/Time:       2025-08-08 21:56:04.273 +0900
Launch Time:     2025-08-08 21:56:03.979 +0900
OS Version:      macOS 15.4.1 (24E263)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         7648K
Physical footprint (peak):  7648K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 55533: 589 nodes malloced for 16082 KB
Process 55533: 400 leaks for 16457600 total leaked bytes.
```

### After

```txt
Process:         leak_test [54688]
Path:            /Users/USER/*/leak_test
Load Address:    0x102b84000
Identifier:      leak_test
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [54687]
Target Type:     live task

Date/Time:       2025-08-08 21:54:47.918 +0900
Launch Time:     2025-08-08 21:54:47.833 +0900
OS Version:      macOS 15.4.1 (24E263)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         2768K
Physical footprint (peak):  2768K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 54688: 189 nodes malloced for 10 KB
Process 54688: 0 leaks for 0 total leaked bytes.
```